### PR TITLE
Use ActiveSupport::Logger with tagged logging

### DIFF
--- a/lib/le.rb
+++ b/lib/le.rb
@@ -30,7 +30,8 @@ module Le
     host = Le::Host.new(token, region, opt_local, opt_debug, opt_ssl, opt_datahub_endpoint, opt_host_id, opt_custom_host, opt_udp_port, opt_use_data_endpoint)
 
     if defined?(ActiveSupport::TaggedLogging) &&  opt_tag
-      logger = ActiveSupport::TaggedLogging.new(Logger.new(host))
+      logger_klass = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger : Logger
+      logger = ActiveSupport::TaggedLogging.new(logger_klass.new(host))
     elsif defined?(ActiveSupport::Logger)
       logger = ActiveSupport::Logger.new(host)
       logger.formatter = host.formatter if host.respond_to?(:formatter)


### PR DESCRIPTION
Prefer using ActiveSupport::Logger with tagged logging (tag: true) if available, instead of plain ::Logger.
This allows for log silencing and other additional functionality.

Note: Though ActiveSupport::Logger is required through ActiveSupport::TaggedLogging (active_support v5.2), there is still a check in place for the definition.