### PR TITLE
[LOG-12179] TLS default; housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# IDEs
+.vscode
+.idea
+
+# ruby plugins
+.rakeTasks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.3.1
+  - 2.0.0
+  - 1.9.3
+  - jruby-19mode
+before_install:
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: ruby
+
 rvm:
-  - 2.3.1
-  - 2.0.0
-  - 1.9.3
+  - 2.6.5
+  - 2.3
+  - 2.0
+  - 1.9
   - jruby-19mode
+
 before_install:
+  - gem update --system
   - gem install bundler
+
+script:
+  - make test
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,27 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
+    concurrent-ruby (1.1.5)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
     minitest (5.12.2)
     rake (13.0.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   bundler
   minitest
   r7insight!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
-  bundler
-  minitest
+  activesupport (~> 6.0.0)
+  bundler (~> 2.0.0)
+  minitest (~> 5.12.2)
   r7insight!
-  rake
+  rake (~> 13.0.0)
 
 BUNDLED WITH
    2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    r7insight (2.7.6)
+    r7insight (3.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,22 @@
+PATH
+  remote: .
+  specs:
+    r7insight (2.7.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.12.2)
+    rake (13.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  minitest
+  r7insight!
+  rake
+
+BUNDLED WITH
+   2.0.2

--- a/LE.gemspec
+++ b/LE.gemspec
@@ -25,8 +25,8 @@ DESC
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_development_dependency 'activesupport'
-  gem.add_development_dependency 'bundler'
-  gem.add_development_dependency 'minitest'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'activesupport', '~> 6.0.0'
+  gem.add_development_dependency 'bundler', '~> 2.0.0'
+  gem.add_development_dependency 'minitest', '~> 5.12.2'
+  gem.add_development_dependency 'rake', '~> 13.0.0'
 end

--- a/LE.gemspec
+++ b/LE.gemspec
@@ -1,29 +1,32 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+require 'English'
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'le'
 
 Gem::Specification.new do |gem|
-  gem.name	= "r7insight"
-  gem.version	= "2.7.6"
-  gem.date	= Time.now
-  gem.summary	= "InsightOps logging plugin"
-  gem.licenses    = ["MIT"]
-  gem.description	=<<EOD
+  gem.name = 'r7insight'
+  gem.version = '2.7.6'
+  gem.date = Time.now
+  gem.summary = 'InsightOps logging plugin'
+  gem.licenses    = ['MIT']
+  gem.description = <<DESC
 
 
-EOD
+DESC
 
-  gem.authors	= ["Mark Lacomber", "Stephen Hynes"]
-  gem.email	= "support@rapid7.com"
-  gem.homepage    = "https://github.com/rapid7/r7insight_ruby"
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.authors = ['Mark Lacomber', 'Stephen Hynes']
+  gem.email = 'support@rapid7.com'
+  gem.homepage = 'https://github.com/rapid7/r7insight_ruby'
+  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
-  gem.add_development_dependency "bundler"
-  gem.add_development_dependency "rake"
+  gem.add_development_dependency 'activesupport'
+  gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'minitest'
-
+  gem.add_development_dependency 'rake'
 end

--- a/LE.gemspec
+++ b/LE.gemspec
@@ -8,7 +8,7 @@ require 'le'
 
 Gem::Specification.new do |gem|
   gem.name = 'r7insight'
-  gem.version = '2.7.6'
+  gem.version = '3.0.0'
   gem.date = Time.now
   gem.summary = 'InsightOps logging plugin'
   gem.licenses    = ['MIT']

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 test: ## Run the unit tests
 	bundle exec rake --trace
 
+build: ## Build the ruby gem
+	gem build LE.gemspec
+
 bump-major: ## Bump the major version (1.0.0 -> 2.0.0)
 	@which bump || (echo "You do not have 'bump' installed or in your PATH.\n" \
 		"Please run 'gem install bump'\n" "GitHub: https://github.com/gregorym/bump" && false)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,31 @@
 .PHONY: test
-.DEFAULT_GOAL := test
+.DEFAULT_GOAL := help
 
-test:
+test: ## Run the unit tests
 	bundle exec rake --trace
+
+bump-major: ## Bump the major version (1.0.0 -> 2.0.0)
+	@which bump || (echo "You do not have 'bump' installed or in your PATH.\n" \
+		"Please run 'gem install bump'\n" "GitHub: https://github.com/gregorym/bump" && false)
+	@bump major
+
+bump-minor: ## Bump the minor version (0.1.0 -> 0.2.0)
+	@which bump || (echo "You do not have 'bump' installed or in your PATH.\n" \
+		"Please run 'gem install bump'\n" "GitHub: https://github.com/gregorym/bump" && false)
+	@bump minor
+
+bump-patch: ## Bump the patch version (0.0.1 -> 0.0.2)
+	@which bump || (echo "You do not have 'bump' installed or in your PATH.\n" \
+		"Please run 'gem install bump'\n" "GitHub: https://github.com/gregorym/bump" && false)
+	@bump patch
+
+help: ## Shows help
+	@IFS=$$'\n' ; \
+    help_lines=(`fgrep -h "##" ${MAKEFILE_LIST} | fgrep -v fgrep | sed -e 's/\\$$//'`); \
+    for help_line in $${help_lines[@]}; do \
+        IFS=$$'#' ; \
+        help_split=($$help_line) ; \
+        help_command=`echo $${help_split[0]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+        help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+        printf "%-30s %s\n" $$help_command $$help_info ; \
+    done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+.DEFAULT_GOAL := test
+
+test:
+	bundle exec rake --trace

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test build bump-major bump-minor bump-patch help
 .DEFAULT_GOAL := help
 
 test: ## Run the unit tests

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Example
     Rails.logger.warn("warning message")
     Rails.logger.debug("debug message")
 
+Development
+-------
+When developing some functionality you will require the following:  
+- ruby version `2.6.5`
+- bundle version `2.0.2`
+- gem version `2.5.2.3`
+- rvm version `1.29.9`
+- `bundle install --jobs=3 --retry=3`
+- `make test` for testing
+
+JetBrains RubyMine was used to develop this gem.
 
 Howto
 -----

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Development flow
 - Push again into the branch
 - Pull request should get approved and merged
 
+Deployment information for Rapid7 developers
+- Pull down the merged master which includes the Pull request changes
+- `make build`
+- `gem push r7insight<VERSION>.gem`
+
 JetBrains RubyMine was used to develop this gem.  
 
 Howto
@@ -60,7 +65,9 @@ Then from the cmd line run the following command:
 This will install the gem on your local environment.
 
 The next step is to configure the default rails logger to use the insightops logger.  
+Ensure you add a `require` to load in the package:
 
+    require 'le.rb'
 
 In your environment configuration file ( for production : `config/environments/production.rb`), add the following:
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,23 @@ Example
 
 Development
 -------
-When developing some functionality you will require the following:  
+When developing functionality you will require the following:  
 - ruby version `2.6.5`
 - bundle version `2.0.2`
-- gem version `2.5.2.3`
+- gem version `3.0.6`
 - rvm version `1.29.9`
-- `bundle install --jobs=3 --retry=3`
-- `make test` for testing
 
-JetBrains RubyMine was used to develop this gem.
+Development flow
+- Fork the main repository
+- Clone your fork
+- Implement functionality
+- `make test` for testing
+- Push and create a pull request into the main Rapid7 repository
+- Once pull request is approved `make (major|minor|patch)` for bumping versions
+- Push again into the branch
+- Pull request should get approved and merged
+
+JetBrains RubyMine was used to develop this gem.  
 
 Howto
 -----

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,18 @@
-require "bundler/gem_tasks"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  t.libs = ['lib','test']
-  t.test_files = Dir.glob("test/**/*_spec.rb").sort
+  t.libs = %w[lib test]
+  t.test_files = Dir.glob('test/**/*_spec.rb').sort
   t.verbose = true
 end
 
-task :default => [:test]
-task :spec => [:test]
+task default: [:test]
+task spec: [:test]
 
-desc "Open an irb session preloaded with this library"
+desc 'Open an irb session preloaded with this library'
 task :console do
-  sh "irb -rubygems -I lib -r le.rb"
+  sh 'irb -rubygems -I lib -r le.rb'
 end

--- a/lib/le/host.rb
+++ b/lib/le/host.rb
@@ -14,8 +14,7 @@ module Le
     module InstanceMethods
       def formatter
         proc do |severity, datetime, _, msg|
-          message = "#{datetime} "
-          message << format_message(msg, severity)
+          "#{datetime} #{format_message(msg, severity)}"
         end
       end
 

--- a/lib/le/host.rb
+++ b/lib/le/host.rb
@@ -1,10 +1,16 @@
-module Le
-  module Host
+# frozen_string_literal: true
 
-    def self.new(token, region, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, use_data_endpoint)
-      Le::Host::CONNECTION.new(token, region, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, use_data_endpoint)
+module Le
+  # InsightOps Logging Host
+  module Host
+    def self.new(token, region, local, debug, ssl, datahub_endpoint, host_id,
+                 custom_host, udp_port, use_data_endpoint)
+      Le::Host::CONNECTION.new(token, region, local, debug, ssl,
+                               datahub_endpoint, host_id, custom_host,
+                               udp_port, use_data_endpoint)
     end
 
+    # Log formatter
     module InstanceMethods
       def formatter
         proc do |severity, datetime, _, msg|
@@ -19,7 +25,6 @@ module Le
         "severity=#{severity}, #{message_in.lstrip}"
       end
     end
-
   end
 end
 

--- a/lib/le/host/connection.rb
+++ b/lib/le/host/connection.rb
@@ -1,146 +1,131 @@
+# frozen_string_literal: true
+
 require 'socket'
 require 'openssl'
-require 'thread'
 require 'timeout'
 require 'uri'
 
 module Le
   module Host
+    # Class for connecting to InsightOps and handling the connection
     class CONNECTION
       DATA_ENDPOINT = '.data.logs.insight.rapid7.com'
       DATA_PORT_UNSECURE = 80
       DATA_PORT_SECURE = 443
-      API_SSL_PORT = 20000
-      SHUTDOWN_COMMAND = "DIE!DIE!"  # magic command string for async worker to shutdown
-      SHUTDOWN_MAX_WAIT = 10         # max seconds to wait for queue to clear on shutdown
-      SHUTDOWN_WAIT_STEP = 0.2       # sleep duration (seconds) while waiting to shutdown
-
+      API_SSL_PORT = 20_000
+      SHUTDOWN_COMMAND = 'DIE!DIE!' # magic shutdown command string for worker
+      SHUTDOWN_MAX_WAIT = 10 # max seconds to wait for queue shutdown clearing
+      SHUTDOWN_WAIT_STEP = 0.2 # sleep duration (seconds) while shutting down
 
       include Le::Host::InstanceMethods
-#!      attr_accessor :token, :queue, :started, :thread, :conn, :local, :debug, :ssl, :datahub_enabled, :dathub_ip, :datahub_port, :host_id, :custom_host, :host_name_enabled, :host_name
-      attr_accessor :token, :region,:queue, :started, :thread, :conn, :local, :debug, :ssl, :datahub_enabled, :datahub_ip, :datahub_port, :datahub_endpoint, :host_id, :host_name_enabled, :host_name, :custom_host, :udp_port, :use_data_endpoint
+      attr_accessor :token, :region, :queue, :started, :thread, :conn, :local,
+                    :debug, :ssl, :datahub_enabled, :datahub_ip, :datahub_port,
+                    :datahub_endpoint, :host_id, :host_name_enabled, :host_name,
+                    :custom_host, :udp_port, :use_data_endpoint
 
-
-      def initialize(token, region, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp_port, use_data_endpoint)
-          if local
-            device = if local.class <= TrueClass
-              if defined?(Rails)
-                Rails.root.join("log","#{Rails.env}.log")
-              else
-                STDOUT
-              end
-            else
-            local
-            end
+      def initialize(token, region, local, debug, ssl, datahub_endpoint,
+                     host_id, custom_host, udp_port, use_data_endpoint)
+        if local
+          device = if local.class <= TrueClass
+                     if defined?(Rails)
+                       Rails.root.join('log', "#{Rails.env}.log")
+                     else
+                       STDOUT
+                     end
+                   else
+                     local
+                   end
           @logger_console = Logger.new(device)
-          end
+        end
 
-          @region = region
-          @local = !!local
-          @debug= debug
-          @ssl = ssl
-          @udp_port = udp_port
-          @use_data_endpoint = use_data_endpoint
+        @region = region
+        @local = local.nil? || local == false ? false : true # Replace "!!"
+        @debug = debug
+        @ssl = ssl
+        @udp_port = udp_port
+        @use_data_endpoint = use_data_endpoint
 
         @datahub_endpoint = datahub_endpoint
         if !@datahub_endpoint[0].empty?
-          @datahub_enabled=true
-          @datahub_ip="#{@datahub_endpoint[0]}"
-          @datahub_port=@datahub_endpoint[1]
+          @datahub_enabled = true
+          @datahub_ip = (@datahub_endpoint[0]).to_s
+          @datahub_port = @datahub_endpoint[1]
         else
-          @datahub_enabled=false
+          @datahub_enabled = false
         end
 
-
-        if (@datahub_enabled && @ssl)
-          puts ("\n\nYou Cannot have DataHub and SSL enabled at the same time.  Please set SSL value to false in your environment.rb file or used Token-Based logging by leaving the Datahub IP address blank. Exiting application. \n\n")
+        if @datahub_enabled && @ssl
+          puts("\n\nYou Cannot have DataHub and SSL enabled at the same time.
+ Please set SSL value to false in your environment.rb file or used Token-Based
+ logging by leaving the Datahub IP address blank. Exiting application. \n\n")
           exit
         end
 
- #check if region was specified
+        # Check if region was specified
         if region.empty?
-          puts ("\n\nYou need to specify a region. Options: eu, us")
+          puts("\n\nYou need to specify a region. Options: eu, us")
         end
 
- #check if DataHub is enabled... if datahub is not enabled, set the token to the token's parameter.  If DH is enabled, make the token empty.
-        if (!datahub_enabled)
-           @token = token
+        # Check if DataHub is enabled
+        # If datahub is not enabled, set the token to the token's parameter
+        # If DH is enabled, make the token empty.
+        if !datahub_enabled
+          @token = token
         else
           @token = ''
 
- #! NOTE THIS @datahub_port conditional MAY NEED TO BE CHANGED IF SSL CAN'T WORK WITH DH
-          @datahub_port = @datahub_port.empty? ?  API_SSL_PORT : datahub_port
+          # !NOTE THIS @datahub_port conditional MAY NEED TO BE CHANGED IF SSL
+          # CAN'T WORK WITH DH
+          @datahub_port = @datahub_port.empty? ? API_SSL_PORT : datahub_port
           @datahub_ip = datahub_ip
         end
 
-        @host_name_enabled=custom_host[0];
-        @host_name= custom_host[1];
+        @host_name_enabled = custom_host[0]
+        @host_name = custom_host[1]
 
-
-# Check if host_id is empty -- if not assign, if so, make it an empty string.
-       if !host_id.empty?
+        if !host_id.empty?
           @host_id = host_id
           @host_id = "host_id=#{host_id}"
         else
-          @host_id=''
+          @host_id = ''
         end
 
+        #  If no host name is given but required, assign the machine name
+        if @host_name_enabled
+          @host_name = Socket.gethostname if host_name.empty?
 
-
-#assign host_name, if no host name is given and host_name_enabled = true... assign a host_name based on the machine name.
-       if @host_name_enabled
-          if host_name.empty?
-            @host_name=Socket.gethostname
-          end
-
-          @host_name="host_name=#{@host_name}"
+          @host_name = "host_name=#{@host_name}"
         end
-
 
         @queue = Queue.new
         @started = false
         @thread = nil
 
-        if @debug
-          self.init_debug
-        end
+        init_debug if @debug
         at_exit { shutdown! }
       end
 
       def init_debug
-        filePath = "r7insightGem.log"
-        if File.exist?('log/')
-          filePath = "log/r7insightGem.log"
-        end
-        @debug_logger = Logger.new(filePath)
+        file_path = 'r7insightGem.log'
+        file_path = 'log/r7insightGem.log' if File.exist?('log/')
+        @debug_logger = Logger.new(file_path)
       end
 
       def dbg(message)
-        if @debug
-          @debug_logger.add(Logger::Severity::DEBUG, message)
-        end
+        @debug_logger.add(Logger::Severity::DEBUG, message) if @debug
       end
 
       def write(message)
+        message = "#{message} #{host_id}" unless host_id.empty?
+        message = "#{message} #{host_name}" if host_name_enabled
 
-        if !host_id.empty?
-          message = "#{message} #{ host_id }"
-        end
+        @logger_console.add(Logger::Severity::UNKNOWN, message) if @local
 
-        if host_name_enabled
-          message="#{message} #{ host_name }"
-        end
-
-        if @local
-          @logger_console.add(Logger::Severity::UNKNOWN, message)
-        end
-
-        if message.scan(/\n/).empty?
-          @queue << "#{ @token } #{ message } \n"
-        else
-          @queue << "#{ message.gsub(/^/, "#{ @token } [#{ random_message_id }]") }\n"
-        end
-
+        @queue << if message.scan(/\n/).empty?
+                    "#{@token} #{message} \n"
+                  else
+                    "#{message.gsub(/^/, "#{@token} [#{random_message_id}]")}\n"
+                  end
 
         if @started
           check_async_thread
@@ -150,45 +135,36 @@ module Le
       end
 
       def start_async_thread
-        @thread = Thread.new { run() }
-        dbg "LE: Asynchronous socket writer started"
+        @thread = Thread.new { run }
+        dbg 'LE: Asynchronous socket writer started'
         @started = true
       end
 
       def check_async_thread
-        if not(@thread && @thread.alive?)
-          @thread = Thread.new { run() }
-        end
+        @thread = Thread.new { run } unless @thread&.alive?
       end
 
       def close
-        dbg "LE: Closing asynchronous socket writer"
+        dbg 'LE: Closing asynchronous socket writer'
         @started = false
       end
 
-      def openConnection
-        dbg "LE: Reopening connection to Logentries API server"
-
+      def open_connection
+        dbg 'LE: Reopening connection to Logentries API server'
 
         if @use_data_endpoint
-            host = @region + DATA_ENDPOINT
+          host = @region + DATA_ENDPOINT
 
-            if @ssl
-              port = DATA_PORT_SECURE
-            else
-              port = DATA_PORT_UNSECURE
-            end
+          port = @ssl ? DATA_PORT_SECURE : DATA_PORT_UNSECURE
+        elsif @udp_port
+          host = @region + DATA_ENDPOINT
+          port = @udp_port
+        elsif @datahub_enabled
+          host = @datahub_ip
+          port = @datahub_port
         else
-          if @udp_port
-            host = @region + DATA_ENDPOINT
-            port = @udp_port
-          elsif @datahub_enabled
-            host = @datahub_ip
-            port = @datahub_port
-          else
-            host = @region + DATA_ENDPOINT
-            port = @ssl ? DATA_PORT_SECURE: DATA_PORT_UNSECURE
-          end
+          host = @region + DATA_ENDPOINT
+          port = @ssl ? DATA_PORT_SECURE : DATA_PORT_UNSECURE
         end
 
         if @udp_port
@@ -198,24 +174,27 @@ module Le
           socket = TCPSocket.new(host, port)
 
           if @ssl
-	    cert_store = OpenSSL::X509::Store.new
-	    cert_store.set_default_paths
+            cert_store = OpenSSL::X509::Store.new
+            cert_store.set_default_paths
 
-            ssl_context = OpenSSL::SSL::SSLContext.new()
-	    ssl_context.cert_store = cert_store
+            ssl_context = OpenSSL::SSL::SSLContext.new
+            ssl_context.cert_store = cert_store
 
-            ssl_version_candidates = [:TLSv1_2, :TLSv1_1, :TLSv1]
+            ssl_version_candidates = %i[TLSv1_2 TLSv1_1 TLSv1]
             ssl_version_candidates = ssl_version_candidates.select { |version| OpenSSL::SSL::SSLContext::METHODS.include? version }
             if ssl_version_candidates.empty?
-                raise "Could not find suitable TLS version"
+              raise 'Could not find suitable TLS version'
             end
-	    # currently we only set the version when we have no choice
-            ssl_context.ssl_version = ssl_version_candidates[0] if ssl_version_candidates.length == 1
+
+            # currently we only set the version when we have no choice
+            if ssl_version_candidates.length == 1
+              ssl_context.ssl_version = ssl_version_candidates[0]
+            end
             ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
             ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
             ssl_socket.hostname = host if ssl_socket.respond_to?(:hostname=)
             ssl_socket.sync_close = true
-            Timeout::timeout(10) do
+            Timeout.timeout(10) do
               ssl_socket.connect
             end
             @conn = ssl_socket
@@ -224,92 +203,100 @@ module Le
           end
         end
 
-        dbg "LE: Connection established"
+        dbg 'LE: Connection established'
       end
 
-      def reopenConnection
-        closeConnection
+      def reopen_connection
+        close_connection
         root_delay = 0.1
         loop do
           begin
-            openConnection
+            open_connection
             break
-          rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
-            dbg "LE: Unable to connect to Logentries due to timeout(#{ $! })"
-          rescue
-            dbg "LE: Got exception in reopenConnection - #{ $! }"
+          rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ECONNREFUSED,
+                 Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
+            dbg "LE: Unable to connect to Logentries due to timeout
+(#{$ERROR_INFO})"
+          rescue StandardError
+            dbg "LE: Got exception in reopenConnection - #{$ERROR_INFO}"
             raise
           end
           root_delay *= 2
-          if root_delay >= 10
-            root_delay = 10
-          end
+          root_delay = 10 if root_delay >= 10
           wait_for = (root_delay + rand(root_delay)).to_i
-          dbg "LE: Waiting for #{ wait_for }ms"
+          dbg "LE: Waiting for #{wait_for}ms"
           sleep(wait_for)
         end
       end
 
-      def closeConnection
+      def close_connection
         begin
           if @conn.respond_to?(:sysclose)
             @conn.sysclose
           elsif @conn.respond_to?(:close)
             @conn.close
           end
-        rescue
-          dbg "LE: couldn't close connection, close with exception - #{ $! }"
+        rescue StandardError
+          dbg "LE: couldn't close connection, close with exception -
+ #{$ERROR_INFO}"
         ensure
           @conn = nil
         end
       end
 
       def run
-        reopenConnection
+        reopen_connection
 
         loop do
           data = @queue.pop
           break if data == SHUTDOWN_COMMAND
+
           loop do
             begin
               @conn.write(data)
-            rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
-              dbg "LE: Connection timeout(#{ $! }), try to reopen connection"
-              reopenConnection
+            rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::ECONNREFUSED,
+                   Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError
+              dbg "LE: Connection timeout(#{$ERROR_INFO}), try to reopen
+connection"
+              reopen_connection
               next
-            rescue
-              dbg("LE: Got exception in run loop - #{ $! }")
+            rescue StandardError
+              dbg("LE: Got exception in run loop - #{$ERROR_INFO}")
               raise
             end
-
             break
           end
         end
 
-        dbg "LE: Closing Asynchronous socket writer"
+        dbg 'LE: Closing Asynchronous socket writer'
 
-        closeConnection
+        close_connection
       end
 
       private
-        def random_message_id
-          @random_message_id_sample_space ||= ('0'..'9').to_a.concat(('A'..'Z').to_a)
-          (0..5).map{ @random_message_id_sample_space.sample }.join
-        end
 
-        # at_exit handler.
-        # Attempts to clear the queue and terminate the async worker cleanly before process ends.
-        def shutdown!
-          return unless @started
-          dbg "LE: commencing shutdown, queue has #{queue.size} entries to clear"
-          queue << SHUTDOWN_COMMAND
-          SHUTDOWN_MAX_WAIT.div(SHUTDOWN_WAIT_STEP).times do
-            break if queue.empty?
-            sleep SHUTDOWN_WAIT_STEP
-          end
-          dbg "LE: shutdown complete, queue is #{queue.empty? ? '' : 'not '}empty with #{queue.size} entries"
-        end
+      def random_message_id
+        @random_message_id_sample_space ||= ('0'..'9').to_a.concat(('A'..'Z')
+                                                                       .to_a)
+        (0..5).map { @random_message_id_sample_space.sample }.join
+      end
 
+      # at_exit handler.
+      # Attempts to clear the queue and terminate the async worker cleanly
+      # before process ends.
+      def shutdown!
+        return unless @started
+
+        dbg "LE: commencing shutdown, queue has #{queue.size} entries to clear"
+        queue << SHUTDOWN_COMMAND
+        SHUTDOWN_MAX_WAIT.div(SHUTDOWN_WAIT_STEP).times do
+          break if queue.empty?
+
+          sleep SHUTDOWN_WAIT_STEP
+        end
+        dbg "LE: shutdown complete, queue is #{queue.empty? ? '' : 'not '}
+             empty with #{queue.size} entries"
+      end
     end
   end
 end

--- a/lib/le/host/connection.rb
+++ b/lib/le/host/connection.rb
@@ -180,16 +180,8 @@ module Le
             ssl_context = OpenSSL::SSL::SSLContext.new
             ssl_context.cert_store = cert_store
 
-            ssl_version_candidates = %i[TLSv1_2 TLSv1_1 TLSv1]
-            ssl_version_candidates = ssl_version_candidates.select { |version| OpenSSL::SSL::SSLContext::METHODS.include? version }
-            if ssl_version_candidates.empty?
-              raise 'Could not find suitable TLS version'
-            end
-
-            # currently we only set the version when we have no choice
-            if ssl_version_candidates.length == 1
-              ssl_context.ssl_version = ssl_version_candidates[0]
-            end
+            ssl_context.min_version = OpenSSL::SSL::TLS1_VERSION
+            ssl_context.max_version = OpenSSL::SSL::TLS1_2_VERSION
             ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
             ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
             ssl_socket.hostname = host if ssl_socket.respond_to?(:hostname=)

--- a/test/host_spec.rb
+++ b/test/host_spec.rb
@@ -19,5 +19,9 @@ describe Le::Host do
     Le::Host::CONNECTION.new(token, region, local, debug, ssl, datahub_endpoint,
                              host_id, custom_host, udp, use_data_endpoint)
   end
-  specify { _(host).must_be_instance_of Le::Host::CONNECTION }
+  describe 'host' do
+    it 'is an instance of CONNECTION' do
+      assert_instance_of(Le::Host::CONNECTION, host)
+    end
+  end
 end

--- a/test/host_spec.rb
+++ b/test/host_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Le::Host do
   let(:token)   { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
+  let(:region)  { 'eu' }
   let(:local)   { false }
   let(:debug)   { false }
   let(:ssl)     { true }
@@ -12,10 +13,11 @@ describe Le::Host do
   let(:datahub_endpoint) { ['', 10_000] }
   let(:host_id) { '' }
   let(:custom_host) { [false, ''] }
-  let(:data_endpoint) { true }
+  let(:use_data_endpoint) { true }
 
   let(:host) do
-    Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, data_endpoint)
+    Le::Host::CONNECTION.new(token, region, local, debug, ssl, datahub_endpoint,
+                             host_id, custom_host, udp, use_data_endpoint)
   end
   specify { _(host).must_be_instance_of Le::Host::CONNECTION }
 end

--- a/test/host_spec.rb
+++ b/test/host_spec.rb
@@ -1,22 +1,21 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-
 describe Le::Host do
-
   let(:token)   { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:local)   { false }
   let(:debug)   { false }
   let(:ssl)     { true }
   let(:udp)     { nil }
 
+  let(:datahub_endpoint) { ['', 10_000] }
+  let(:host_id) { '' }
+  let(:custom_host) { [false, ''] }
+  let(:data_endpoint) { true }
 
-
-  let(:datahub_endpoint) { ["", 10000] }
-  let(:host_id) { ""}
-  let(:custom_host)	{ [false, ""]}
-  let(:data_endpoint) {true}
-
-  let(:host)     { Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, data_endpoint) }
+  let(:host) do
+    Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, data_endpoint)
+  end
   specify { _(host).must_be_instance_of Le::Host::CONNECTION }
-
 end

--- a/test/host_spec.rb
+++ b/test/host_spec.rb
@@ -16,8 +16,7 @@ describe Le::Host do
   let(:custom_host)	{ [false, ""]}
   let(:data_endpoint) {true}
 
-  #let(:host)    { Le::Host.new(token, local, debug, ssl) }
-  let(:host)     { Le::Host::HTTP.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, data_endpoint) }
-  specify { host.must_be_instance_of Le::Host::HTTP }
+  let(:host)     { Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, data_endpoint) }
+  specify { _(host).must_be_instance_of Le::Host::CONNECTION }
 
 end

--- a/test/http_spec.rb
+++ b/test/http_spec.rb
@@ -1,18 +1,19 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'pathname'
 
 describe Le::Host::CONNECTION do
-
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:local)              { false }
   let(:debug)              { false }
   let(:ssl)                { false }
   let(:udp)                { nil }
 
-  let(:datahub_endpoint)  { ["", 10000]}
-  let(:host_id)           {""}
-  let(:custom_host)       {[false, ""]}
-  let(:endpoint)       {false}
+  let(:datahub_endpoint)  { ['', 10_000] }
+  let(:host_id)           { '' }
+  let(:custom_host)       { [false, ''] }
+  let(:endpoint) { false }
 
   let(:host)               { Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
 

--- a/test/http_spec.rb
+++ b/test/http_spec.rb
@@ -23,12 +23,30 @@ describe Le::Host::CONNECTION do
 
   let(:logger_console) { host.instance_variable_get(:@logger_console) }
 
-  specify { _(host).must_be_instance_of Le::Host::CONNECTION }
-  specify { _(host.region).must_equal 'eu' }
-  specify { _(host.local).must_equal false }
-  specify { _(host.debug).must_equal false }
-  specify { _(host.ssl).must_equal false }
-  specify { _(host.udp_port).nil? }
-  specify { _(host_id).must_equal '' }
-  specify { _(custom_host).must_equal [false, ''] }
+  describe 'host' do
+    it 'is an instance of CONNECTION' do
+      assert_instance_of(Le::Host::CONNECTION, host)
+    end
+    it 'region is expected value' do
+      assert_equal(host.region, 'eu')
+    end
+    it 'local is expected value' do
+      refute(host.local)
+    end
+    it 'debug is expected value' do
+      refute(host.debug)
+    end
+    it 'ssl is expected value' do
+      refute(host.ssl)
+    end
+    it 'udp port is expected value' do
+      assert_nil(host.udp_port)
+    end
+    it 'id is expected value' do
+      assert_equal(host_id, '')
+    end
+    it 'custom_host is expected value' do
+      assert_equal(custom_host, [false, ''])
+    end
+  end
 end

--- a/test/http_spec.rb
+++ b/test/http_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'pathname'
 
-describe Le::Host::HTTP do
+describe Le::Host::CONNECTION do
 
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:local)              { false }
@@ -14,20 +14,15 @@ describe Le::Host::HTTP do
   let(:custom_host)       {[false, ""]}
   let(:endpoint)       {false}
 
-
-
-#  let(:host)               { Le::Host::HTTP.new(token, local, debug, ssl) }
-  let(:host)               { Le::Host::HTTP.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
+  let(:host)               { Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
 
   let(:logger_console)     { host.instance_variable_get(:@logger_console) }
-  let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
 
-  specify { host.must_be_instance_of Le::Host::HTTP }
-  specify { host.local.must_equal false }
-  specify { host.debug.must_equal false }
-  specify { host.ssl.must_equal false }
-  specify { host.udp_port.must_equal nil }
-  specify {host_id.must_equal ""}
-  specify {custom_host.must_equal [false, ""]}
-
+  specify { _(host).must_be_instance_of Le::Host::CONNECTION }
+  specify { _(host.local).must_equal false }
+  specify { _(host.debug).must_equal false }
+  specify { _(host.ssl).must_equal false }
+  specify { _(host.udp_port).nil? }
+  specify { _(host_id).must_equal '' }
+  specify { _(custom_host).must_equal [false, ''] }
 end

--- a/test/http_spec.rb
+++ b/test/http_spec.rb
@@ -5,6 +5,7 @@ require 'pathname'
 
 describe Le::Host::CONNECTION do
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
+  let(:region)             { 'eu' }
   let(:local)              { false }
   let(:debug)              { false }
   let(:ssl)                { false }
@@ -15,11 +16,15 @@ describe Le::Host::CONNECTION do
   let(:custom_host)       { [false, ''] }
   let(:endpoint) { false }
 
-  let(:host)               { Le::Host::CONNECTION.new(token, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
+  let(:host) do
+    Le::Host::CONNECTION.new(token, region, local, debug, ssl, datahub_endpoint,
+                             host_id, custom_host, udp, endpoint)
+  end
 
-  let(:logger_console)     { host.instance_variable_get(:@logger_console) }
+  let(:logger_console) { host.instance_variable_get(:@logger_console) }
 
   specify { _(host).must_be_instance_of Le::Host::CONNECTION }
+  specify { _(host.region).must_equal 'eu' }
   specify { _(host.local).must_equal false }
   specify { _(host.debug).must_equal false }
   specify { _(host.ssl).must_equal false }

--- a/test/le_spec.rb
+++ b/test/le_spec.rb
@@ -12,45 +12,76 @@ describe Le do
   let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
 
   describe 'when non-Rails environment' do
-    describe 'and initialised with just a token' do
+    describe 'is initialised with just a token' do
       let(:logger) { Le.new(token, region) }
-      specify { _(logger).must_be_instance_of Logger }
-      specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-      specify { _(logdev.local).must_equal false }
-      specify { _(logger_console).must_be_nil }
 
-      describe 'then :ssl is true' do
-        specify { _(logdev.ssl).must_equal true }
+      describe 'logger' do
+        it 'should be a Logger instance' do
+          assert_instance_of(Logger, logger)
+        end
+      end
+
+      describe 'logger device' do
+        it 'is an instance of Le::Host::CONNECTION' do
+          assert_instance_of(Le::Host::CONNECTION, logdev)
+        end
+        it 'local is false' do
+          refute(logdev.local)
+        end
+        it 'ssl is true' do
+          assert(logdev.ssl)
+        end
+      end
+
+      describe 'logger console' do
+        it 'is nil' do
+          assert_nil(logger_console)
+        end
       end
     end
 
-    describe 'and initialized with :ssl => true' do
+    describe 'is initialized with :ssl => true' do
       let(:logger) { Le.new(token, region, ssl: true) }
 
-      describe 'then :ssl is true' do
-        specify { _(logdev.ssl).must_equal true }
+      describe 'logger device' do
+        it 'ssl is true' do
+          assert(logdev.ssl)
+        end
       end
     end
 
-    describe 'and initialized with :ssl => false' do
+    describe 'is initialized with :ssl => false' do
       let(:logger) { Le.new(token, region, ssl: false) }
 
-      describe 'then :ssl is false' do
-        specify { _(logdev.ssl).must_equal false }
+      describe 'logger device' do
+        it 'ssl is false' do
+          refute(logdev.ssl)
+        end
       end
     end
 
-    describe 'and :local is false' do
-      specify { _(logdev.local).must_equal false }
-      specify { _(logger_console).must_be_nil }
+    it 'logger device local is false' do
+      refute(logdev.local)
     end
 
-    describe 'and :local is true' do
+    it 'logger console is nil' do
+      assert_nil(logger_console)
+    end
+
+    describe 'local is set to true' do
       let(:local) { true }
 
-      specify { _(logdev.local).must_equal true }
-      specify { _(logger_console).must_be_instance_of Logger }
-      specify { _(logger_console_dev).must_be_instance_of IO }
+      it 'logger device local is true' do
+        assert(logdev.local)
+      end
+
+      it 'logger console is instance of Logger' do
+        assert_instance_of(Logger, logger_console)
+      end
+
+      it 'logger console device instance of IO' do
+        assert_instance_of(IO, logger_console_dev)
+      end
     end
 
     describe 'and :local => ' do
@@ -63,31 +94,83 @@ describe Le do
       describe 'Pathname' do
         let(:log_file) { local_test_log }
 
-        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-        specify { _(logdev.local).must_equal true }
-        specify { _(logger_console).must_be_instance_of Logger }
-        specify { _(logger_console_dev).must_be_instance_of File }
-        specify { _(logger_console_dev.path).must_match 'local_log.log' }
+        describe 'logger device' do
+          it 'is an instance of our CONNECTION' do
+            assert_instance_of(Le::Host::CONNECTION, logdev)
+          end
+          it 'local is true' do
+            assert(logdev.local)
+          end
+        end
+
+        describe 'logger console' do
+          it 'is an instance of Logger' do
+            assert_instance_of(Logger, logger_console)
+          end
+        end
+
+        describe 'logger console device' do
+          it 'is an instance of File' do
+            assert_instance_of(File, logger_console_dev)
+          end
+          it 'path matches specified log file' do
+            assert_match('local_log.log', logger_console_dev.path)
+          end
+        end
       end
 
       describe 'path string' do
         let(:log_file) { local_test_log.to_s }
 
-        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-        specify { _(logdev.local).must_equal true }
-        specify { _(logger_console).must_be_instance_of Logger }
-        specify { _(logger_console_dev).must_be_instance_of File }
-        specify { _(logger_console_dev.path).must_match 'local_log.log' }
+        describe 'logger device' do
+          it 'is an instance of CONNECTION' do
+            assert_instance_of(Le::Host::CONNECTION, logdev)
+          end
+          it 'local is true' do
+            assert(logdev.local)
+          end
+        end
+
+        describe 'logger console' do
+          it 'is an instance of Logger' do
+            assert_instance_of(Logger, logger_console)
+          end
+        end
+
+        describe 'logger console device' do
+          it 'is an instance of File' do
+            assert_instance_of(File, logger_console_dev)
+          end
+          it 'path matches expected log filename' do
+            assert_match('local_log.log', logger_console_dev.path)
+          end
+        end
       end
 
       describe 'File' do
         let(:log_file) { File.new(local_test_log, 'w') }
 
-        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-        specify { _(logdev.local).must_equal true }
-        specify { _(logger_console).must_be_instance_of Logger }
-        specify { _(logger_console_dev).must_be_instance_of File }
-        specify { _(logger_console_dev.path).must_match 'local_log.log' }
+        describe 'logger device' do
+          it 'is an instance of CONNECTION' do
+            assert_instance_of(Le::Host::CONNECTION, logdev)
+          end
+          it 'local is true' do
+            assert(logdev.local)
+          end
+        end
+        describe 'logger console' do
+          it 'is an instance of Logger' do
+            assert_instance_of(Logger, logger_console)
+          end
+        end
+        describe 'logger console device' do
+          it 'is an instance of File' do
+            assert_instance_of(File, logger_console_dev)
+          end
+          it 'path matches expected log location' do
+            assert_match('local_log.log', logger_console_dev.path)
+          end
+        end
       end
     end
   end
@@ -108,22 +191,36 @@ describe Le do
       Object.send(:remove_const, :Rails)
     end
 
-    describe 'and :ssl is true' do
-      specify { _(logdev.ssl).must_equal true }
+    it 'ssl is true' do
+      assert(logdev.ssl)
     end
 
-    describe 'and :local is false' do
-      specify { _(logdev.local).must_equal false }
-      specify { _(logger_console).must_be_nil }
+    it 'local is false' do
+      refute(logdev.local)
+      assert_nil(logger_console)
     end
 
     describe 'and :local is true' do
       let(:local) { true }
 
-      specify { _(logdev.local).must_equal true }
-      specify { _(logger_console).must_be_instance_of Logger }
-      specify { _(logger_console_dev).must_be_instance_of File }
-      specify { _(logger_console_dev.path).must_match 'test.log' }
+      describe 'logger device' do
+        it 'local is true' do
+          assert(logdev.local)
+        end
+      end
+      describe 'logger console' do
+        it 'is an instance of Logger' do
+          assert_instance_of(Logger, logger_console)
+        end
+      end
+      describe 'logger console device' do
+        it 'is an instance of File' do
+          assert_instance_of(File, logger_console_dev)
+        end
+        it 'path matches expected log filename' do
+          assert_match('test.log', logger_console_dev.path)
+        end
+      end
     end
 
     describe 'and :local => ' do
@@ -136,31 +233,79 @@ describe Le do
       describe 'Pathname' do
         let(:log_file) { local_test_log }
 
-        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-        specify { _(logdev.local).must_equal true }
-        specify { _(logger_console).must_be_instance_of Logger }
-        specify { _(logger_console_dev).must_be_instance_of File }
-        specify { _(logger_console_dev.path).must_match 'local_log.log' }
+        describe 'logger device' do
+          it 'is an instance of CONNECTION' do
+            assert_instance_of(Le::Host::CONNECTION, logdev)
+          end
+          it 'local is true' do
+            assert(logdev.local)
+          end
+        end
+        describe 'logger console' do
+          it 'is an instance of Logger' do
+            assert_instance_of(Logger, logger_console)
+          end
+        end
+        describe 'logger console device' do
+          it 'is an instance of File' do
+            assert_instance_of(File, logger_console_dev)
+          end
+          it 'path matches expected log filename' do
+            assert_match('local_log.log', logger_console_dev.path)
+          end
+        end
       end
 
       describe 'path string' do
         let(:log_file) { local_test_log.to_s }
 
-        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-        specify { _(logdev.local).must_equal true }
-        specify { _(logger_console).must_be_instance_of Logger }
-        specify { _(logger_console_dev).must_be_instance_of File }
-        specify { _(logger_console_dev.path).must_match 'local_log.log' }
+        describe 'logger device' do
+          it 'is an instance of CONNECTION' do
+            assert_instance_of(Le::Host::CONNECTION, logdev)
+          end
+          it 'local is true' do
+            assert(logdev.local)
+          end
+        end
+        describe 'logger console' do
+          it 'is an instance of Logger' do
+            assert_instance_of(Logger, logger_console)
+          end
+        end
+        describe 'logger console device' do
+          it 'is an instance of File' do
+            assert_instance_of(File, logger_console_dev)
+          end
+          it 'path matches expected log filename' do
+            assert_match('local_log.log', logger_console_dev.path)
+          end
+        end
       end
 
       describe 'File' do
         let(:log_file) { File.new(local_test_log, 'w') }
 
-        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
-        specify { _(logdev.local).must_equal true }
-        specify { _(logger_console).must_be_instance_of Logger }
-        specify { _(logger_console_dev).must_be_instance_of File }
-        specify { _(logger_console_dev.path).must_match 'local_log.log' }
+        describe 'logger device' do
+          it 'is an instance of CONNECTION' do
+            assert_instance_of(Le::Host::CONNECTION, logdev)
+          end
+          it 'local is true' do
+            assert(logdev.local)
+          end
+        end
+        describe 'logger console' do
+          it 'is an instance of Logger' do
+            assert_instance_of(Logger, logger_console)
+          end
+        end
+        describe 'logger console device' do
+          it 'is an instance of File' do
+            assert_instance_of(File, logger_console_dev)
+          end
+          it 'path matches expected log filename' do
+            assert_match('local_log.log', logger_console_dev.path)
+          end
+        end
       end
     end
   end

--- a/test/le_spec.rb
+++ b/test/le_spec.rb
@@ -12,12 +12,32 @@ describe Le do
   let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
 
   describe 'when non-Rails environment' do
-    describe 'when initialised with just a token' do
+    describe 'and initialised with just a token' do
       let(:logger) { Le.new(token, region) }
       specify { _(logger).must_be_instance_of Logger }
       specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
       specify { _(logdev.local).must_equal false }
       specify { _(logger_console).must_be_nil }
+
+      describe 'then :ssl is true' do
+        specify { _(logdev.ssl).must_equal true }
+      end
+    end
+
+    describe 'and initialized with :ssl => true' do
+      let(:logger) { Le.new(token, region, ssl: true) }
+
+      describe 'then :ssl is true' do
+        specify { _(logdev.ssl).must_equal true }
+      end
+    end
+
+    describe 'and initialized with :ssl => false' do
+      let(:logger) { Le.new(token, region, ssl: false) }
+
+      describe 'then :ssl is false' do
+        specify { _(logdev.ssl).must_equal false }
+      end
     end
 
     describe 'and :local is false' do
@@ -86,6 +106,10 @@ describe Le do
     end
     after do
       Object.send(:remove_const, :Rails)
+    end
+
+    describe 'and :ssl is true' do
+      specify { _(logdev.ssl).must_equal true }
     end
 
     describe 'and :local is false' do

--- a/test/le_spec.rb
+++ b/test/le_spec.rb
@@ -14,23 +14,23 @@ describe Le do
 
     describe "when initialised with just a token" do
       let(:logger)         { Le.new(token) }
-      specify { logger.must_be_instance_of Logger }
-      specify { logdev.must_be_instance_of Le::Host::HTTP }
-      specify { logdev.local.must_equal false }
-      specify { logger_console.must_be_nil }
+      specify { _(logger).must_be_instance_of Logger }
+      specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+      specify { _(logdev.local).must_equal false }
+      specify { _(logger_console).must_be_nil }
     end
 
     describe "and :local is false" do
-      specify { logdev.local.must_equal false }
-      specify { logger_console.must_be_nil }
+      specify { _(logdev.local).must_equal false }
+      specify { _(logger_console).must_be_nil }
     end
 
     describe "and :local is true" do
       let(:local)   { true }
 
-      specify { logdev.local.must_equal true }
-      specify { logger_console.must_be_instance_of Logger }
-      specify { logger_console_dev.must_be_instance_of IO }
+      specify { _(logdev.local).must_equal true }
+      specify { _(logger_console).must_be_instance_of Logger }
+      specify { _(logger_console_dev).must_be_instance_of IO }
     end
 
 
@@ -41,31 +41,31 @@ describe Le do
       describe "Pathname" do
         let(:log_file) { local_test_log }
 
-        specify { logdev.must_be_instance_of Le::Host::HTTP }
-        specify { logdev.local.must_equal true }
-        specify { logger_console.must_be_instance_of Logger }
-        specify { logger_console_dev.must_be_instance_of File }
-        specify { logger_console_dev.path.must_match 'local_log.log' }
+        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+        specify { _(logdev.local).must_equal true }
+        specify { _(logger_console).must_be_instance_of Logger }
+        specify { _(logger_console_dev).must_be_instance_of File }
+        specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
       describe "path string" do
         let(:log_file) { local_test_log.to_s }
 
-        specify { logdev.must_be_instance_of Le::Host::HTTP }
-        specify { logdev.local.must_equal true }
-        specify { logger_console.must_be_instance_of Logger }
-        specify { logger_console_dev.must_be_instance_of File }
-        specify { logger_console_dev.path.must_match 'local_log.log' }
+        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+        specify { _(logdev.local).must_equal true }
+        specify { _(logger_console).must_be_instance_of Logger }
+        specify { _(logger_console_dev).must_be_instance_of File }
+        specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
       describe "File" do
         let(:log_file) { File.new(local_test_log, 'w') }
 
-        specify { logdev.must_be_instance_of Le::Host::HTTP }
-        specify { logdev.local.must_equal true }
-        specify { logger_console.must_be_instance_of Logger }
-        specify { logger_console_dev.must_be_instance_of File }
-        specify { logger_console_dev.path.must_match 'local_log.log' }
+        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+        specify { _(logdev.local).must_equal true }
+        specify { _(logger_console).must_be_instance_of Logger }
+        specify { _(logger_console_dev).must_be_instance_of File }
+        specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
     end
@@ -88,17 +88,17 @@ describe Le do
     end
 
     describe "and :local is false" do
-      specify { logdev.local.must_equal false }
-      specify { logger_console.must_be_nil }
+      specify { _(logdev.local).must_equal false }
+      specify { _(logger_console).must_be_nil }
     end
 
     describe "and :local is true" do
       let(:local)   { true }
 
-      specify { logdev.local.must_equal true }
-      specify { logger_console.must_be_instance_of Logger }
-      specify { logger_console_dev.must_be_instance_of File }
-      specify { logger_console_dev.path.must_match 'test.log' }
+      specify { _(logdev.local).must_equal true }
+      specify { _(logger_console).must_be_instance_of Logger }
+      specify { _(logger_console_dev).must_be_instance_of File }
+      specify { _(logger_console_dev.path).must_match 'test.log' }
     end
 
     describe "and :local => " do
@@ -108,31 +108,31 @@ describe Le do
       describe "Pathname" do
         let(:log_file) { local_test_log }
 
-        specify { logdev.must_be_instance_of Le::Host::HTTP }
-        specify { logdev.local.must_equal true }
-        specify { logger_console.must_be_instance_of Logger }
-        specify { logger_console_dev.must_be_instance_of File }
-        specify { logger_console_dev.path.must_match 'local_log.log' }
+        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+        specify { _(logdev.local).must_equal true }
+        specify { _(logger_console).must_be_instance_of Logger }
+        specify { _(logger_console_dev).must_be_instance_of File }
+        specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
       describe "path string" do
         let(:log_file) { local_test_log.to_s }
 
-        specify { logdev.must_be_instance_of Le::Host::HTTP }
-        specify { logdev.local.must_equal true }
-        specify { logger_console.must_be_instance_of Logger }
-        specify { logger_console_dev.must_be_instance_of File }
-        specify { logger_console_dev.path.must_match 'local_log.log' }
+        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+        specify { _(logdev.local).must_equal true }
+        specify { _(logger_console).must_be_instance_of Logger }
+        specify { _(logger_console_dev).must_be_instance_of File }
+        specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
       describe "File" do
         let(:log_file) { File.new(local_test_log, 'w') }
 
-        specify { logdev.must_be_instance_of Le::Host::HTTP }
-        specify { logdev.local.must_equal true }
-        specify { logger_console.must_be_instance_of Logger }
-        specify { logger_console_dev.must_be_instance_of File }
-        specify { logger_console_dev.path.must_match 'local_log.log' }
+        specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
+        specify { _(logdev.local).must_equal true }
+        specify { _(logger_console).must_be_instance_of Logger }
+        specify { _(logger_console_dev).must_be_instance_of File }
+        specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
     end

--- a/test/le_spec.rb
+++ b/test/le_spec.rb
@@ -5,14 +5,15 @@ require 'spec_helper'
 describe Le do
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:local)              { false }
-  let(:logger)             { Le.new(token, local: local) }
+  let(:region)             { 'eu' }
+  let(:logger)             { Le.new(token, region, local: local) }
   let(:logdev)             { logger.instance_variable_get(:@logdev).dev }
   let(:logger_console)     { logdev.instance_variable_get(:@logger_console) }
   let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
 
   describe 'when non-Rails environment' do
     describe 'when initialised with just a token' do
-      let(:logger) { Le.new(token) }
+      let(:logger) { Le.new(token, region) }
       specify { _(logger).must_be_instance_of Logger }
       specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
       specify { _(logdev.local).must_equal false }

--- a/test/le_spec.rb
+++ b/test/le_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Le do
-
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:local)              { false }
   let(:logger)             { Le.new(token, local: local) }
@@ -9,36 +10,36 @@ describe Le do
   let(:logger_console)     { logdev.instance_variable_get(:@logger_console) }
   let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
 
-
-  describe "when non-Rails environment" do
-
-    describe "when initialised with just a token" do
-      let(:logger)         { Le.new(token) }
+  describe 'when non-Rails environment' do
+    describe 'when initialised with just a token' do
+      let(:logger) { Le.new(token) }
       specify { _(logger).must_be_instance_of Logger }
       specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
       specify { _(logdev.local).must_equal false }
       specify { _(logger_console).must_be_nil }
     end
 
-    describe "and :local is false" do
+    describe 'and :local is false' do
       specify { _(logdev.local).must_equal false }
       specify { _(logger_console).must_be_nil }
     end
 
-    describe "and :local is true" do
-      let(:local)   { true }
+    describe 'and :local is true' do
+      let(:local) { true }
 
       specify { _(logdev.local).must_equal true }
       specify { _(logger_console).must_be_instance_of Logger }
       specify { _(logger_console_dev).must_be_instance_of IO }
     end
 
+    describe 'and :local => ' do
+      let(:local_test_log) do
+        Pathname.new(File.dirname(__FILE__))
+                .join('fixtures', 'log', 'local_log.log')
+      end
+      let(:local) { log_file }
 
-    describe "and :local => " do
-      let(:local_test_log) { Pathname.new(File.dirname(__FILE__)).join('fixtures','log','local_log.log') }
-      let(:local)   { log_file }
-
-      describe "Pathname" do
+      describe 'Pathname' do
         let(:log_file) { local_test_log }
 
         specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
@@ -48,7 +49,7 @@ describe Le do
         specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
-      describe "path string" do
+      describe 'path string' do
         let(:log_file) { local_test_log.to_s }
 
         specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
@@ -58,7 +59,7 @@ describe Le do
         specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
-      describe "File" do
+      describe 'File' do
         let(:log_file) { File.new(local_test_log, 'w') }
 
         specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
@@ -67,17 +68,16 @@ describe Le do
         specify { _(logger_console_dev).must_be_instance_of File }
         specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
-
     end
-
   end
 
-  describe "when Rails environment" do
+  describe 'when Rails environment' do
     before do
       class Rails
         def self.root
           Pathname.new(File.dirname(__FILE__)).join('fixtures')
         end
+
         def self.env
           'test'
         end
@@ -87,13 +87,13 @@ describe Le do
       Object.send(:remove_const, :Rails)
     end
 
-    describe "and :local is false" do
+    describe 'and :local is false' do
       specify { _(logdev.local).must_equal false }
       specify { _(logger_console).must_be_nil }
     end
 
-    describe "and :local is true" do
-      let(:local)   { true }
+    describe 'and :local is true' do
+      let(:local) { true }
 
       specify { _(logdev.local).must_equal true }
       specify { _(logger_console).must_be_instance_of Logger }
@@ -101,11 +101,14 @@ describe Le do
       specify { _(logger_console_dev.path).must_match 'test.log' }
     end
 
-    describe "and :local => " do
-      let(:local_test_log) { Pathname.new(File.dirname(__FILE__)).join('fixtures','log','local_log.log') }
-      let(:local)   { log_file }
+    describe 'and :local => ' do
+      let(:local_test_log) do
+        Pathname.new(File.dirname(__FILE__))
+                .join('fixtures', 'log', 'local_log.log')
+      end
+      let(:local) { log_file }
 
-      describe "Pathname" do
+      describe 'Pathname' do
         let(:log_file) { local_test_log }
 
         specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
@@ -115,7 +118,7 @@ describe Le do
         specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
-      describe "path string" do
+      describe 'path string' do
         let(:log_file) { local_test_log.to_s }
 
         specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
@@ -125,7 +128,7 @@ describe Le do
         specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
 
-      describe "File" do
+      describe 'File' do
         let(:log_file) { File.new(local_test_log, 'w') }
 
         specify { _(logdev).must_be_instance_of Le::Host::CONNECTION }
@@ -134,9 +137,6 @@ describe Le do
         specify { _(logger_console_dev).must_be_instance_of File }
         specify { _(logger_console_dev.path).must_match 'local_log.log' }
       end
-
     end
-
   end
-
 end

--- a/test/region.rb
+++ b/test/region.rb
@@ -4,7 +4,7 @@ require 'pathname'
 logger = Le.new('185a71d5-32a7-4007-a12d-3295c75a10e2', 'eu')
 logger.info("ssl")
 
-describe Le::Host::HTTP do
+describe Le::Host::CONNECTION do
 
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
   let(:region)             {'eu'}
@@ -18,13 +18,11 @@ describe Le::Host::HTTP do
   let(:custom_host)       {[false, ""]}
   let(:endpoint)          {false}
 
-
-  let(:host)               { Le::Host::HTTP.new(token, region, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
+  let(:host)               { Le::Host::CONNECTION.new(token, region, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
 
   let(:logger_console)     { host.instance_variable_get(:@logger_console) }
-  let(:logger_console_dev) { logger_console.instance_variable_get(:@logdev).dev }
 
-  specify { host.must_be_instance_of Le::Host::HTTP }
+  specify { host.must_be_instance_of Le::Host::CONNECTION }
   specify {host.region.must_equal 'eu'}
   specify { host.local.must_equal false }
   specify { host.debug.must_equal false }

--- a/test/region.rb
+++ b/test/region.rb
@@ -1,35 +1,40 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'pathname'
 
 logger = Le.new('185a71d5-32a7-4007-a12d-3295c75a10e2', 'eu')
-logger.info("ssl")
+logger.info('ssl')
 
 describe Le::Host::CONNECTION do
-
   let(:token)              { '11111111-2222-3333-aaaa-bbbbbbbbbbbb' }
-  let(:region)             {'eu'}
+  let(:region)             { 'eu' }
   let(:local)              { false }
   let(:debug)              { false }
   let(:ssl)                { false }
   let(:udp)                { nil }
 
-  let(:datahub_endpoint)  { ["", 10000]}
-  let(:host_id)           {""}
-  let(:custom_host)       {[false, ""]}
-  let(:endpoint)          {false}
+  let(:datahub_endpoint)  { ['', 10_000] }
+  let(:host_id)           { '' }
+  let(:custom_host)       { [false, ''] }
+  let(:endpoint)          { false }
 
-  let(:host)               { Le::Host::CONNECTION.new(token, region, local, debug, ssl, datahub_endpoint, host_id, custom_host, udp, endpoint) }
+  let(:host) do
+  Le::Host::CONNECTION.new(token, region, local,
+                           debug, ssl,
+                           datahub_endpoint,
+                           host_id, custom_host,
+                           udp, endpoint)
+  end
 
-  let(:logger_console)     { host.instance_variable_get(:@logger_console) }
+  let(:logger_console) { host.instance_variable_get(:@logger_console) }
 
   specify { host.must_be_instance_of Le::Host::CONNECTION }
-  specify {host.region.must_equal 'eu'}
+  specify { host.region.must_equal 'eu' }
   specify { host.local.must_equal false }
   specify { host.debug.must_equal false }
   specify { host.ssl.must_equal false }
   specify { host.udp_port.must_equal nil }
-  specify {host_id.must_equal ""}
-  specify {custom_host.must_equal [false, ""]}
-
-
+  specify { host_id.must_equal '' }
+  specify { custom_host.must_equal [false, ''] }
 end

--- a/test/region.rb
+++ b/test/region.rb
@@ -29,12 +29,30 @@ describe Le::Host::CONNECTION do
 
   let(:logger_console) { host.instance_variable_get(:@logger_console) }
 
-  specify { host.must_be_instance_of Le::Host::CONNECTION }
-  specify { host.region.must_equal 'eu' }
-  specify { host.local.must_equal false }
-  specify { host.debug.must_equal false }
-  specify { host.ssl.must_equal false }
-  specify { host.udp_port.must_equal nil }
-  specify { host_id.must_equal '' }
-  specify { custom_host.must_equal [false, ''] }
+  describe 'host' do
+    it 'is an instance of CONNECTION' do
+      assert_instance_of(Le::Host::CONNECTION, host)
+    end
+    it 'region is expected value' do
+      assert_equal(host.region, 'eu')
+    end
+    it 'local is expected value' do
+      refute(host.local)
+    end
+    it 'debug is expected value' do
+      refute(host.debug)
+    end
+    it 'ssl is expected value' do
+      refute(host.ssl)
+    end
+    it 'udp port is expected value' do
+      assert_nil(host.udp_port)
+    end
+    it 'id is expected value' do
+      assert_equal(host_id, '')
+    end
+    it 'custom_host is expected value' do
+      assert_equal(custom_host, [false, ''])
+    end
+  end
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'le'


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
Add tests to ensure TLS/SSL default.
Fix failing TravisCI build.
Fix warnings/testing.
Add versioning/documentation.
Pin versions.
Addressed two PRs from `le_ruby` as recommended by @rjacobs-r7 :
https://github.com/rapid7/le_ruby/pull/72
https://github.com/rapid7/le_ruby/pull/70

## Testing
<!-- Describe how this change was tested -->
4 UTs.
Check data is being streamed from script and from build of locally installed package.
Also debugged to ensure correct TLS default path is taken.

> require './lib/le.rb'
> 
> logger = Le.new('<TOKEN>', 'eu')
> logger.info('why do we fall?')
> logger.debug('your anger gives you great power')
> logger.error('everythings impossible until someone does it')
