### PR TITLE
Set ssl_context.max_version to TLS1_2_VERSION rather than TLS1_3_V…

### DIFF
--- a/lib/r7_insight/host/connection.rb
+++ b/lib/r7_insight/host/connection.rb
@@ -189,7 +189,8 @@ module R7Insight
             ssl_context.cert_store = cert_store
 
             ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
-            ssl_context.max_version = OpenSSL::SSL::TLS1_3_VERSION
+            # For older versions of openssl (prior to 1.1.1) missing support for TLSv1.3
+            ssl_context.max_version = defined?(OpenSSL::SSL::TLS1_3_VERSION) ? OpenSSL::SSL::TLS1_3_VERSION : OpenSSL::SSL::TLS1_2_VERSION
             ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
             ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
             ssl_socket.hostname = host if ssl_socket.respond_to?(:hostname=)


### PR DESCRIPTION
We are using Heroku for hosting one of our RoR apps and we are not able to integrate with r7insight logs with the ''uninitialized constant OpenSSL::SSL::TLS1_3_VERSION'' errors.  We are on latest stack on Heroku, which is using "OpenSSL 1.1.0g  2 Nov 2017", while OpenSSL started supporting TLSv1.3 with version 1.1.1.

We have no way of integration with r7insight logs unless we set ssl_context.max_version to OpenSSL::SSL::TLS1_2_VERSION for older versions of OpenSSL.