### PR TITLE
Check OpenSSL version before checking TLS version

### DIFF
--- a/lib/r7_insight/host/connection.rb
+++ b/lib/r7_insight/host/connection.rb
@@ -188,10 +188,16 @@ module R7Insight
             ssl_context = OpenSSL::SSL::SSLContext.new
             ssl_context.cert_store = cert_store
 
-            if OpenSSL::VERSION >= "2.1.0"
+            if defined?(OpenSSL::SSL::SSLContext.method_defined? :min_version)
               ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
+            end
+            if defined?(OpenSSL::SSL::SSLContext.method_defined? :max_version)
               # For older versions of openssl (prior to 1.1.1) missing support for TLSv1.3
-              ssl_context.max_version = defined?(OpenSSL::SSL::TLS1_3_VERSION) ? OpenSSL::SSL::TLS1_3_VERSION : OpenSSL::SSL::TLS1_2_VERSION
+              ssl_context.max_version = if defined?(OpenSSL::SSL::TLS1_3_VERSION)
+                                          OpenSSL::SSL::TLS1_3_VERSION
+                                        else
+                                          OpenSSL::SSL::TLS1_2_VERSION
+                                        end
             end
             ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
             ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)

--- a/lib/r7_insight/host/connection.rb
+++ b/lib/r7_insight/host/connection.rb
@@ -188,10 +188,10 @@ module R7Insight
             ssl_context = OpenSSL::SSL::SSLContext.new
             ssl_context.cert_store = cert_store
 
-            if defined?(OpenSSL::SSL::SSLContext.method_defined? :min_version)
+            if defined?(ssl_context.min_version)
               ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
             end
-            if defined?(OpenSSL::SSL::SSLContext.method_defined? :max_version)
+            if defined?(ssl_context.max_version)
               # For older versions of openssl (prior to 1.1.1) missing support for TLSv1.3
               ssl_context.max_version = if defined?(OpenSSL::SSL::TLS1_3_VERSION)
                                           OpenSSL::SSL::TLS1_3_VERSION

--- a/lib/r7_insight/host/connection.rb
+++ b/lib/r7_insight/host/connection.rb
@@ -188,9 +188,11 @@ module R7Insight
             ssl_context = OpenSSL::SSL::SSLContext.new
             ssl_context.cert_store = cert_store
 
-            ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
-            # For older versions of openssl (prior to 1.1.1) missing support for TLSv1.3
-            ssl_context.max_version = defined?(OpenSSL::SSL::TLS1_3_VERSION) ? OpenSSL::SSL::TLS1_3_VERSION : OpenSSL::SSL::TLS1_2_VERSION
+            if OpenSSL::VERSION >= "2.1.0"
+              ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
+              # For older versions of openssl (prior to 1.1.1) missing support for TLSv1.3
+              ssl_context.max_version = defined?(OpenSSL::SSL::TLS1_3_VERSION) ? OpenSSL::SSL::TLS1_3_VERSION : OpenSSL::SSL::TLS1_2_VERSION
+            end
             ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
             ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
             ssl_socket.hostname = host if ssl_socket.respond_to?(:hostname=)

--- a/lib/r7_insight/host/connection.rb
+++ b/lib/r7_insight/host/connection.rb
@@ -188,10 +188,10 @@ module R7Insight
             ssl_context = OpenSSL::SSL::SSLContext.new
             ssl_context.cert_store = cert_store
 
-            if defined?(ssl_context.min_version)
+            if OpenSSL::SSL::SSLContext.method_defined? :min_version=
               ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
             end
-            if defined?(ssl_context.max_version)
+            if OpenSSL::SSL::SSLContext.method_defined? :max_version=
               # For older versions of openssl (prior to 1.1.1) missing support for TLSv1.3
               ssl_context.max_version = if defined?(OpenSSL::SSL::TLS1_3_VERSION)
                                           OpenSSL::SSL::TLS1_3_VERSION


### PR DESCRIPTION
Currently, versions of ruby with older versions of OpenSSL doesn't work with the gem. This PR fixes that. 

Looking at this commit. Seems like you need a minimum of 2.1.0 OpenSSL version for it to work.
https://github.com/ruby/openssl/commit/5653599e150bd92d8631858fe6e0def1f9a3c33d